### PR TITLE
Make inner class 'Result' private;refactor too long line

### DIFF
--- a/src/jttt/Core/Strategy/AlphaBetaStrategy.java
+++ b/src/jttt/Core/Strategy/AlphaBetaStrategy.java
@@ -102,7 +102,7 @@ public class AlphaBetaStrategy implements AIMoveStrategy {
         return score + depth;
     }
 
-    public class Result {
+    private class Result {
         private int move;
         private int score;
 

--- a/test/jttt/Core/UI/CommandLineUITest.java
+++ b/test/jttt/Core/UI/CommandLineUITest.java
@@ -29,7 +29,10 @@ public class CommandLineUITest {
 
     @Test
     public void emptyBoardIsDisplayedCorrectly() {
-        CommandLineUI ui = new CommandLineUI(new Game(new PlayerFactory()), new BufferedInputStream(System.in), new PrintStream(System.out));
+        CommandLineUI ui = new CommandLineUI(
+                new Game(new PlayerFactory()),
+                new BufferedInputStream(System.in),
+                new PrintStream(System.out));
         ui.createNewGame(3, 1);
         Assert.assertEquals("" +
                         "[1][2][3]\n" +


### PR DESCRIPTION
- CommandLineUI object constructor was too long so put each argument on a new line.
- Inner class 'Result' was public so made it private
