### PR TITLE
Fix Open/Closed Principal violation in CommandLineUI

### DIFF
--- a/src/jttt/Core/Board/Board.java
+++ b/src/jttt/Core/Board/Board.java
@@ -13,6 +13,7 @@ import static java.util.stream.IntStream.range;
 public class Board {
     private static final int POSITIVE_OFFSET = 1;
     private static final int NEGATIVE_OFFSET = -1;
+    private static final int DISPLAY_POSITION_OFFSET = 1;
     private int dimension;
     private List<Mark> cells;
 
@@ -38,9 +39,9 @@ public class Board {
         return dimension * dimension;
     }
 
-    public Board playCounterInPosition(int position, Mark mark) {
-        if (validPosition(position)) {
-            cells.set(position - POSITIVE_OFFSET, mark);
+    public Board playCounterInPosition(int displayPositionIndex, Mark mark) {
+        if (validDisplayPosition(displayPositionIndex)) {
+            cells.set(toZeroIndexedPosition(displayPositionIndex), mark);
         }
         return new Board(dimension, cells);
     }
@@ -66,12 +67,12 @@ public class Board {
         return (lineOptional.isPresent()) ? lineOptional.get().findWinner() : Mark.EMPTY;
     }
 
-    public boolean validPosition(int position) {
-        return positionIsWithinRange(position) && !cellIsOccupied(position - POSITIVE_OFFSET);
+    public boolean validDisplayPosition(int displayPositionIndex) {
+        return positionIsWithinRange(displayPositionIndex) && !cellIsOccupied(toZeroIndexedPosition(displayPositionIndex));
     }
 
-    public boolean cellIsOccupied(int cellIndex) {
-        return cells.get(cellIndex) == Mark.X || cells.get(cellIndex) == Mark.O;
+    public boolean cellIsOccupied(int zeroIndexedPosition) {
+        return cells.get(zeroIndexedPosition) == Mark.X || cells.get(zeroIndexedPosition) == Mark.O;
     }
 
     public List<Integer> remainingPositions() {
@@ -98,8 +99,12 @@ public class Board {
         return counterPositions;
     }
 
-    public Mark findMarkAtIndex(int startIndex) {
-        return cells.get(startIndex);
+    public Mark findMarkAtDisplayPosition(int displayPositionIndex) {
+        return findMarkAtIndex(toZeroIndexedPosition(displayPositionIndex));
+    }
+
+    public Mark findMarkAtIndex(int zeroIndexedPosition) {
+        return cells.get(zeroIndexedPosition);
     }
 
     public int numberOfOpenPositions() {
@@ -129,6 +134,10 @@ public class Board {
 
     List<Line> getDiagonals() {
         return Arrays.stream(new int[]{0, dimension - 1}).mapToObj(i -> new Line(getDiagonalCells(i))).collect(toList());
+    }
+
+    private int toZeroIndexedPosition(int displayPositionIndex) {
+        return displayPositionIndex - DISPLAY_POSITION_OFFSET;
     }
 
     private List<Mark> copyOfCells() {
@@ -166,21 +175,21 @@ public class Board {
         return findPositions(Mark.X).size() + findPositions(Mark.O).size();
     }
 
-    private boolean positionIsWithinRange(int position) {
-        return 0 < position && position <= boardSize();
+    private boolean positionIsWithinRange(int displayPositionIndex) {
+        return 0 < displayPositionIndex && displayPositionIndex <= boardSize();
     }
 
-    private int determineLastIndexForDiagonal(int startIndex) {
-        return boardSize() + determineDiagonalIndexDirection(startIndex);
+    private int determineLastIndexForDiagonal(int zeroIndexedPosition) {
+        return boardSize() + determineDiagonalIndexDirection(zeroIndexedPosition);
     }
 
-    private int determineNextDiagonalCellIncrement(int startIndex) {
-        int directionalOffset = determineDiagonalIndexDirection(startIndex);
-        return startIndex == 0 ? dimension + directionalOffset : dimension + (directionalOffset);
+    private int determineNextDiagonalCellIncrement(int zeroIndexedPosition) {
+        int directionalOffset = determineDiagonalIndexDirection(zeroIndexedPosition);
+        return zeroIndexedPosition == 0 ? dimension + directionalOffset : dimension + (directionalOffset);
     }
 
-    private int determineDiagonalIndexDirection(int startIndex) {
-        return startIndex == 0 ? POSITIVE_OFFSET : NEGATIVE_OFFSET;
+    private int determineDiagonalIndexDirection(int zeroIndexedPosition) {
+        return zeroIndexedPosition == 0 ? POSITIVE_OFFSET : NEGATIVE_OFFSET;
     }
 
     private List<Mark> generateEmptyCells() {
@@ -190,5 +199,4 @@ public class Board {
         }
         return initialCells;
     }
-
 }

--- a/src/jttt/Core/Game.java
+++ b/src/jttt/Core/Game.java
@@ -48,10 +48,6 @@ public class Game {
         return players.get(board.findNextCounter());
     }
 
-    public Player.Type getNextPlayerType() {
-        return getNextPlayer().getPlayerType();
-    }
-
     public Board getBoard() {
         return board;
     }
@@ -61,16 +57,18 @@ public class Game {
         board = currentPlayer.playTurn(board, newPosition);
     }
 
-    public void playAIMove() {
-        Player currentPlayer = getNextPlayer();
-        board = currentPlayer.playTurn(board);
-    }
-
     public boolean isGameOver() {
         return board.isGameOver();
     }
 
     public Mark findWinner() {
         return board.findWinner();
+    }
+
+    public void playCurrentPlayerMove() {
+        Player currentPlayer = getNextPlayer();
+        board.playCounterInPosition(
+                currentPlayer.getNextPosition(board),
+                currentPlayer.getMark());
     }
 }

--- a/src/jttt/Core/Players/ComputerPlayer.java
+++ b/src/jttt/Core/Players/ComputerPlayer.java
@@ -4,19 +4,18 @@ import jttt.Core.Board.Board;
 import jttt.Core.Board.Mark;
 import jttt.Core.Strategy.AIMoveStrategy;
 import jttt.Core.Strategy.AIStrategyFactory;
-import jttt.UI.UserInterface;
 
 public class ComputerPlayer extends Player {
     private AIStrategyFactory strategyFactory;
 
-    public ComputerPlayer(Mark mark, UserInterface userInterface) {
-        super(mark, Type.AI , userInterface);
+    public ComputerPlayer(Mark mark) {
+        super(mark, Type.AI, null);
         strategyFactory = new AIStrategyFactory();
     }
 
-    public Board playTurn(Board board) {
+    public int getNextPosition(Board board) {
         AIMoveStrategy strategy = strategyFactory.selectStrategyByBoardSize(board.boardSize());
-        return board.playCounterInPosition(strategy.calculateNextMove(board, mark), mark);
+        return strategy.calculateNextMove(board, mark);
     }
 
     public Board playTurn(Board board, int newPosition) {

--- a/src/jttt/Core/Players/HumanPlayer.java
+++ b/src/jttt/Core/Players/HumanPlayer.java
@@ -10,12 +10,8 @@ public class HumanPlayer extends Player {
         super(mark, Type.HUMAN, userInterface);
     }
 
-    public Board playTurn(Board board) {
-        int nextPosition = userInterface.requestNextPosition();
-        while (!board.validPosition(nextPosition)) {
-            nextPosition = userInterface.requestNextPosition();
-        }
-        return board.playCounterInPosition(nextPosition, mark);
+    public int getNextPosition(Board board) {
+        return userInterface.requestNextPosition(board);
     }
 
     public Board playTurn(Board board, int newPosition) {

--- a/src/jttt/Core/Players/Player.java
+++ b/src/jttt/Core/Players/Player.java
@@ -34,11 +34,7 @@ public abstract class Player {
         return Mark.EMPTY;
     }
 
-    public Type getPlayerType() {
-        return playerType;
-    }
-
-    abstract public Board playTurn(Board board);
+    abstract public int getNextPosition(Board board);
 
     abstract public Board playTurn(Board board, int newPosition);
 }

--- a/src/jttt/Core/Players/PlayerFactory.java
+++ b/src/jttt/Core/Players/PlayerFactory.java
@@ -44,8 +44,8 @@ public class PlayerFactory {
 
     void registerGameTypeWithPlayerTypes() {
         gameTypeOptionToPlayers.put(GameType.HVH, createPlayers(new HumanPlayer(Mark.X, userInterface), new HumanPlayer(Mark.O, userInterface)));
-        gameTypeOptionToPlayers.put(GameType.HVC, createPlayers(new HumanPlayer(Mark.X, userInterface), new ComputerPlayer(Mark.O, userInterface)));
-        gameTypeOptionToPlayers.put(GameType.CVH, createPlayers(new ComputerPlayer(Mark.X, userInterface), new HumanPlayer(Mark.O, userInterface)));
+        gameTypeOptionToPlayers.put(GameType.HVC, createPlayers(new HumanPlayer(Mark.X, userInterface), new ComputerPlayer(Mark.O)));
+        gameTypeOptionToPlayers.put(GameType.CVH, createPlayers(new ComputerPlayer(Mark.X), new HumanPlayer(Mark.O, userInterface)));
     }
 
     ArrayList<Player> createPlayers(Player player1, Player player2) {

--- a/src/jttt/Core/Strategy/AlphaBetaStrategy.java
+++ b/src/jttt/Core/Strategy/AlphaBetaStrategy.java
@@ -99,7 +99,7 @@ public class AlphaBetaStrategy implements AIMoveStrategy {
         } else {
             score = varyScoreUsingDepth(-depth, -score);
         }
-        return new Result((int)score, -1);
+        return new Result((int) score, -1);
     }
 
     private boolean hasWinner(Board currentBoard, Mark empty) {

--- a/src/jttt/UI/UserInterface.java
+++ b/src/jttt/UI/UserInterface.java
@@ -1,5 +1,6 @@
 package jttt.UI;
 
+import jttt.Core.Board.Board;
 import jttt.Core.Board.Mark;
 
 import java.util.function.IntPredicate;
@@ -12,7 +13,7 @@ public interface UserInterface {
 
     int requestGameType();
 
-    int requestNextPosition();
+    int requestNextPosition(Board board);
 
     boolean requestPlayAgain();
 
@@ -24,7 +25,7 @@ public interface UserInterface {
 
     boolean validateDimension(int dimension);
 
-    boolean validPosition(int position);
+    boolean validBoardPosition(int oneIndexedPosition, Board board);
 
     boolean validReplayChoice(int instruction);
 

--- a/test/jttt/Core/Board/BoardTest.java
+++ b/test/jttt/Core/Board/BoardTest.java
@@ -142,32 +142,6 @@ public class BoardTest {
         assertEquals(EMPTY, board.findWinner());
     }
 
-//    @Test
-//    public void createListOfRowLines() {
-//        Mark currentBoard[] = {
-//                X, X, X,
-//                O, O, X,
-//                O, O, X
-//        };
-//        Board board = new Board(3, arrayToList(currentBoard));
-//        assertEquals(3, board.getRows().size());
-//        assertEquals(true, board.getRows().get(0).hasAWinner());
-//    }
-//
-//    @Test
-//    public void createListOfColumnLines() {
-//        Mark currentBoard[] = {
-//                X, X, X,
-//                O, O, X,
-//                O, O, X
-//        };
-//
-//        Board board = new Board(3, arrayToList(currentBoard));
-//        assertEquals(3, board.getColumns().size());
-//        assertEquals(true, board.getColumns().get(2).hasAWinner());
-//    }
-
-
     @Test
     public void getSeveralRemainingPositions() {
         Mark currentBoard[] = {

--- a/test/jttt/Core/Fakes/FakeCommandLineUI.java
+++ b/test/jttt/Core/Fakes/FakeCommandLineUI.java
@@ -3,7 +3,6 @@ package jttt.Core.Fakes;
 import jttt.Core.Board.Board;
 import jttt.Core.Board.Mark;
 import jttt.Core.Game;
-import jttt.Core.Players.Player;
 import jttt.Core.Players.PlayerFactory;
 import jttt.UI.UserInterface;
 
@@ -40,6 +39,22 @@ public class FakeCommandLineUI implements UserInterface {
     }
 
     @Override
+    public int requestNextPosition(Board board) {
+        int nextMove = dummyInputs.remove(0);
+        while (!validBoardPosition(nextMove, board)) {
+            nextMove = dummyInputs.size() > 0 ? dummyInputs.remove(0) : -1;
+        }
+        userHasBeenAskedForNextPosition = true;
+        return nextMove;
+    }
+
+    @Override
+    public boolean validBoardPosition(int oneIndexedPosition, Board board) {
+        return (0 < oneIndexedPosition && oneIndexedPosition <= board.boardSize()) &&
+                !board.cellIsOccupied(oneIndexedPosition - 1);
+    }
+
+    @Override
     public int displayGreetingRequest() {
         return 1;
     }
@@ -60,15 +75,6 @@ public class FakeCommandLineUI implements UserInterface {
             playerType = -1;
         }
         return playerType;
-    }
-
-    public int requestNextPosition() {
-        int nextMove = dummyInputs.remove(0);
-        while (!validDummyPosition(nextMove)) {
-            nextMove = dummyInputs.size() > 0 ? dummyInputs.remove(0) : -1;
-        }
-        userHasBeenAskedForNextPosition = true;
-        return nextMove;
     }
 
     public boolean requestPlayAgain() {
@@ -101,10 +107,6 @@ public class FakeCommandLineUI implements UserInterface {
         return dimension >= 3;
     }
 
-    public boolean validPosition(int position) {
-        return position > 0;
-    }
-
     public boolean validReplayChoice(int instruction) {
         return 0 < instruction && instruction < 3;
     }
@@ -134,11 +136,7 @@ public class FakeCommandLineUI implements UserInterface {
 
     private void playAllMoves() {
         while (!game.isGameOver()) {
-            if (game.getNextPlayerType() == Player.Type.AI) {
-                game.playAIMove();
-            } else {
-                game.playMove(requestNextPosition());
-            }
+            game.playCurrentPlayerMove();
             displayBoard();
         }
     }
@@ -166,9 +164,5 @@ public class FakeCommandLineUI implements UserInterface {
 
     private int calculateDimension(Board board) {
         return (int) Math.sqrt(board.boardSize());
-    }
-
-    private boolean validDummyPosition(int nextMove) {
-        return validate(nextMove, this::validPosition);//&& nextMove <= numberOfInputs;
     }
 }

--- a/test/jttt/Core/GameTest.java
+++ b/test/jttt/Core/GameTest.java
@@ -71,15 +71,9 @@ public class GameTest {
     }
 
     @Test
-    public void gameAskedForComputerMove() {
+    public void playAllMoves() {
         Game game = new Game(new Board(DEFAULT_DIMENSION), CVH_GAME_TYPE, new PlayerFactory());
-        Player playerA = game.getNextPlayer();
-        // maybe defaultGame.getNextPlayerMove() then defaultGame.playMove() but then
-        // either the UI would need to know about player types or
-        // the jttt.Core.Players.Player will need to know about the UI
-        // I can't yet see yet how this should go
-        game.playAIMove();
-        assertEquals(Mark.X, game.getBoard().getCells().get(0));
+        game.playCurrentPlayerMove();
     }
 
     @Test

--- a/test/jttt/Core/Players/ComputerPlayerTest.java
+++ b/test/jttt/Core/Players/ComputerPlayerTest.java
@@ -26,21 +26,21 @@ public class ComputerPlayerTest {
     @Before
     public void setUp() {
         fakeUI = new FakeCommandLineUI();
-        computerXPlayer = new ComputerPlayer(Mark.X, fakeUI);
-        computerOPlayer = new ComputerPlayer(Mark.O, fakeUI);
+        computerXPlayer = new ComputerPlayer(Mark.X);
+        computerOPlayer = new ComputerPlayer(Mark.O);
     }
 
     @Test
     public void createComputerPlayerType() {
         List<Integer> initialState = new ArrayList<>(Arrays.asList(1));
         fakeUI.addDummyHumanMoves(initialState);
-        ComputerPlayer computer = new ComputerPlayer(Mark.X, fakeUI);
+        ComputerPlayer computer = new ComputerPlayer(Mark.X);
         Assert.assertEquals(ComputerPlayer.class, computer.getClass());
     }
 
     @Test
     public void getPlayersOpponent() {
-        Player computerPlayer = new ComputerPlayer(Mark.O, fakeUI);
+        Player computerPlayer = new ComputerPlayer(Mark.O);
         Assert.assertEquals(Mark.X, computerPlayer.opponentCounter());
     }
 
@@ -49,8 +49,9 @@ public class ComputerPlayerTest {
         fakeUI.addDummyDimension(3);
         fakeUI.setGameType(2);
         Board board = new Board(3);
-        board = computerXPlayer.playTurn(board);
-        Assert.assertEquals(1, board.findPositions(Mark.X).size());
+        int nextMove = computerXPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.X);
+        assertEquals(computerXPlayer.getMark(), board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -61,7 +62,9 @@ public class ComputerPlayerTest {
                 X, O, O
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(X, computerXPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerXPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.X);
+        assertEquals(X, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -72,7 +75,9 @@ public class ComputerPlayerTest {
                 O, O, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(X, computerXPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerXPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.X);
+        assertEquals(X, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -83,7 +88,9 @@ public class ComputerPlayerTest {
                 O, O, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(X, computerXPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerXPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.X);
+        assertEquals(X, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -94,7 +101,9 @@ public class ComputerPlayerTest {
                 E, O, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.O);
+        assertEquals(O, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -106,22 +115,26 @@ public class ComputerPlayerTest {
                 E, O, O, X,
         };
         Board board = new Board(4, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(0));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.O);
+        assertEquals(O, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
-    public void firstMoveIsAICounterlphaBetaAlphaBeta_3x3() {
+    public void firstMoveIsAI_3x3() {
         Mark currentBoard[] = {
                 E, E, E,
                 E, E, E,
                 E, E, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(0));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.O);
+        assertEquals(O, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
-    public void firstMoveIsRandomlySelected_4x4() {
+    public void firstMoveIsAI_RandomlySelectedStrategy_4x4() {
         Mark currentBoard[] = {
                 E, E, E, E,
                 E, E, E, E,
@@ -129,54 +142,58 @@ public class ComputerPlayerTest {
                 E, E, E, E,
         };
         Board board = new Board(4, arrayToList(currentBoard));
-        List<Mark> result = computerXPlayer.playTurn(board).getCells();
-        assertThat(result, hasItem(X) );
+        int nextMove = computerXPlayer.getNextPosition(board);
+        board = board.playCounterInPosition(nextMove, Mark.X);
+        assertThat(board.getCells(), hasItem(X) );
     }
 
     @Test
-    public void firstMoveIsCounterOppAlphaBetaAlphaBeta_4x4() {
-        Mark currentBoard[] = {
-                E, E, E, E,
-                E, E, E, E,
-                E, E, E, E,
-                E, E, E, X,
-        };
-        Board board = new Board(4, arrayToList(currentBoard));
-        List<Mark> result = computerOPlayer.playTurn(board).getCells();
-        assertThat(result, hasItem(O) );
-    }
-
-    @Test
-    public void alphaBetaShouldPickPositionToBlockOpponentWin() {
+    public void aiPlayerShouldBlockOpponentWin_1() {
         Mark currentBoard[] = {
                 X, X, E,
                 E, O, X,
                 O, X, O
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        assertEquals(3, nextMove);
     }
 
     @Test
-    public void computerChoosesPositionToBlockOpponent() {
+    public void aiPlayerShouldBlockOpponentWin_2() {
         Mark currentBoard[] = {
                 E, E, X,
                 O, X, E,
                 E, E, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(6));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        assertEquals(7, nextMove);
     }
 
     @Test
-    public void oppStartsOnCornerAIPicksCenter() {
+    public void aiPlayerShouldChooseWinningPosition() {
+        Mark currentBoard[] = {
+                X, E, E,
+                E, O, E,
+                O, E, X
+        };
+        Board board = new Board(3, arrayToList(currentBoard));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        assertEquals(3, nextMove);
+    }
+
+    @Test
+    public void aiPlayerShouldPicksCenter() {
         Mark currentBoard[] = {
                 X, E, E,
                 E, E, E,
                 E, E, E
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(4));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.O);
+        assertEquals(O, board.findMarkAtDisplayPosition(nextMove));
     }
 
     @Test
@@ -187,18 +204,9 @@ public class ComputerPlayerTest {
                 E, E, X
         };
         Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(O, computerOPlayer.playTurn(board).findMarkAtIndex(1));
-    }
-
-    @Test
-    public void mustBlockOpponent() {
-        Mark currentBoard[] = {
-                X, E, E,
-                E, O, E,
-                O, E, X
-        };
-        Board board = new Board(3, arrayToList(currentBoard));
-        assertEquals(X, computerXPlayer.playTurn(board).findMarkAtIndex(2));
+        int nextMove = computerOPlayer.getNextPosition(board);
+        board.playCounterInPosition(nextMove, Mark.O);
+        assertEquals(O, board.findMarkAtDisplayPosition(nextMove));
     }
 
     private List<Mark> arrayToList(Mark[] initialBoard) {

--- a/test/jttt/Core/Players/HumanPlayerTest.java
+++ b/test/jttt/Core/Players/HumanPlayerTest.java
@@ -40,9 +40,10 @@ public class HumanPlayerTest {
         fakeUI.addDummyDimension(3);
         fakeUI.addDummyHumanMoves(initialState);
         fakeUI.setGameType(1);
-        Player player1 = new HumanPlayer(Mark.X, fakeUI);
+        Player humanPlayer = new HumanPlayer(Mark.X, fakeUI);
         Board board = new Board(3);
-        board = player1.playTurn(board);
-        Assert.assertEquals(Mark.X, board.findMarkAtIndex(0));
+        int nextMove = humanPlayer.getNextPosition(board);
+        board = board.playCounterInPosition(nextMove, Mark.X);
+        Assert.assertEquals(Mark.X, board.findMarkAtDisplayPosition(nextMove));
     }
 }

--- a/test/jttt/Core/UI/CommandLineUITest.java
+++ b/test/jttt/Core/UI/CommandLineUITest.java
@@ -104,7 +104,7 @@ public class CommandLineUITest {
         CommandLineUI cli = new CommandLineUI(
                 game, new DisplayStyler(),
                 inputStream, writer);
-        assertEquals(9, cli.requestNextPosition());
+        assertEquals(9, cli.requestNextPosition(game.getBoard()));
         assertThat(output.toString(), containsString(cli.POSITION_REQUEST));
     }
 


### PR DESCRIPTION
@maikon
@jsuchy

CommandLineUI had details about how a particular type of player
should be managed.  I've changed the code such that the Player
is asked for it's move which then either uses an AI algorithm in
the ComputerPlayer's case or asks the UI for a move.

This felt a bit like going back in time as I had removed the need
for the Player to interract with the UI as it wasn't necessary.

I had a comment in my code tests that reminded me that I was in
two minds as to which was the better option: 1) have the UI be responsible
for prompting for moves or 2) have the Player ask the UI for a
move if it is necessary.   It was a trade off, but I hadn't thought
about the OCP violation at the time and so went for the former.  I
now think it is better this way.  
Additionally, this way I think
it will be better for the GUI UI implementation as currently I have the same
OCP violation in there.  I am going to address the GUI implementation next, therefore there is a method in the Player class called ::playTurn(Board board, int nextPosition) which will then go away.
